### PR TITLE
feat: stop estimating gas on tests [APE-1080]

### DIFF
--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -9,6 +9,9 @@ from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 
+from eth_utils.hexadecimal import decode_hex
+
+
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (56, 56),

--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -8,9 +8,7 @@ from ape.types import TransactionSignature
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
-
 from eth_utils.hexadecimal import decode_hex
-
 
 NETWORKS = {
     # chain_id, network_id

--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -5,17 +5,18 @@ from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.exceptions import ApeException
 from ape.types import TransactionSignature
+from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix, decode_hex
-from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (56, 56),
     "testnet": (97, 97),
 }
+
 
 def _create_network_config(
     required_confirmations: int = 1, block_time: int = 3, **kwargs
@@ -33,6 +34,7 @@ def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> Ne
         gas_limit="max",
         **kwargs,
     )
+
 
 class BSCConfig(PluginConfig):
     mainnet: NetworkConfig = _create_network_config()

--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -9,6 +9,7 @@ from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix, decode_hex
+from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 
 NETWORKS = {
     # chain_id, network_id
@@ -16,11 +17,27 @@ NETWORKS = {
     "testnet": (97, 97),
 }
 
+def _create_network_config(
+    required_confirmations: int = 1, block_time: int = 3, **kwargs
+) -> NetworkConfig:
+    return NetworkConfig(
+        required_confirmations=required_confirmations, block_time=block_time, **kwargs
+    )
+
+
+def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
+    return _create_network_config(
+        required_confirmations=0,
+        default_provider=default_provider,
+        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        gas_limit="max",
+        **kwargs,
+    )
 
 class BSCConfig(PluginConfig):
-    mainnet: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=3)
-    testnet: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=3)
-    local: NetworkConfig = NetworkConfig(default_provider="test")
+    mainnet: NetworkConfig = _create_network_config()
+    testnet: NetworkConfig = _create_network_config()
+    local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -8,8 +8,6 @@ from ape.types import TransactionSignature
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape_ethereum.transactions import DynamicFeeTransaction, StaticFeeTransaction, TransactionType
-from eth_typing import HexStr
-from eth_utils import add_0x_prefix, decode_hex
 
 NETWORKS = {
     # chain_id, network_id
@@ -59,7 +57,7 @@ class BSC(Ethereum):
             :class:`~ape.api.transactions.TransactionAPI`
         """
 
-        transaction_type = _get_transaction_type(kwargs.get("type"))
+        transaction_type = self.get_transaction_type(kwargs.get("type"))
         kwargs["type"] = transaction_type.value
         txn_class = _get_transaction_cls(transaction_type)
 
@@ -87,23 +85,14 @@ class BSC(Ethereum):
 
         return txn_class.parse_obj(kwargs)
 
-
-def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> TransactionType:
-    if not _type:
-        return TransactionType.STATIC
-
-    if _type is None:
-        _type = TransactionType.STATIC.value
-    elif isinstance(_type, int):
-        _type = f"0{_type}"
-    elif isinstance(_type, bytes):
-        _type = _type.hex()
-
-    suffix = _type.replace("0x", "")
-    if len(suffix) == 1:
-        _type = f"{_type.rstrip(suffix)}0{suffix}"
-
-    return TransactionType(add_0x_prefix(HexStr(_type)))
+    def get_transaction_type(self, _type: Optional[Union[int, str, bytes]]) -> TransactionType:
+        if _type is None:
+            version = TransactionType.STATIC
+        elif not isinstance(_type, int):
+            version = TransactionType(self.conversion_manager.convert(_type, int))
+        else:
+            version = TransactionType(_type)
+        return version
 
 
 class ApeBSCError(ApeException):

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,0 +1,14 @@
+import pytest
+from ape_ethereum.transactions import TransactionType
+
+
+def test_gas_limit(networks):
+    arbitrum = networks.arbitrum
+    assert arbitrum.config.local.gas_limit == "max"
+
+
+@pytest.mark.parametrize("type", (0, "0x0"))
+def test_create_transaction(networks, type):
+    bsc = networks.bsc
+    txn = bsc.create_transaction(type=type)
+    assert txn.type == TransactionType.STATIC.value

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -3,8 +3,8 @@ from ape_ethereum.transactions import TransactionType
 
 
 def test_gas_limit(networks):
-    arbitrum = networks.arbitrum
-    assert arbitrum.config.local.gas_limit == "max"
+    bsc = networks.bsc
+    assert bsc.config.local.gas_limit == "max"
 
 
 @pytest.mark.parametrize("type", (0, "0x0"))


### PR DESCRIPTION
### What I did


Follow changes from ape-ethereum and stop estimating gas in tests


### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
