### PR TITLE
Fix TransactionType mapping in BSC [APE-1426]

### DIFF
--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -84,7 +84,7 @@ def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> Transactio
     if len(suffix) == 1:
         _type = f"{_type.rstrip(suffix)}0{suffix}"
 
-    return TransactionType(add_0x_prefix(HexStr(_type)))
+    return TransactionType(add_0x_prefix(int(HexStr(_type), 0))
 
 
 class ApeBSCError(ApeException):

--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -84,7 +84,7 @@ def _get_transaction_type(_type: Optional[Union[int, str, bytes]]) -> Transactio
     if len(suffix) == 1:
         _type = f"{_type.rstrip(suffix)}0{suffix}"
 
-    return TransactionType(add_0x_prefix(int(HexStr(_type), 0))
+    return TransactionType(add_0x_prefix(int(HexStr(_type), 0)))
 
 
 class ApeBSCError(ApeException):


### PR DESCRIPTION
### What I did

Just int from hexadecimal representation as TransactionType enum is a int enum.

fixes: bsc RCP transaction querying

### How to verify it

Used it

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
