### PR TITLE
fix: declare opbnb as a mainnet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/ape_bsc/ecosystem.py
+++ b/ape_bsc/ecosystem.py
@@ -17,9 +17,11 @@ NETWORKS = {
 }
 
 
-def _create_config(block_time: int = 3) -> NetworkConfig:
+def _create_config(block_time: int = 3, **kwargs) -> NetworkConfig:
     return create_network_config(
-        block_time=block_time, default_transaction_type=TransactionType.STATIC
+        block_time=block_time,
+        default_transaction_type=TransactionType.STATIC,
+        **kwargs,
     )
 
 
@@ -30,7 +32,7 @@ class BSCConfig(BaseEthereumConfig):
     testnet: NetworkConfig = _create_config()
 
     # opBNB is really fast, hence the low block time.
-    opbnb: NetworkConfig = _create_config(block_time=1)
+    opbnb: NetworkConfig = _create_config(block_time=1, is_mainnet=True)
     opbnb_testnet: NetworkConfig = _create_config(block_time=1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
     ],
     "lint": [
         "black>=24.10.0,<25",  # Auto-formatter and linter
-        "mypy>=1.12.0,<2",  # Static type analyzer
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
@@ -60,7 +60,7 @@ setup(
     url="https://github.com/ApeWorX/ape-bsc",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.8.1,<0.9",
+        "eth-ape>=0.8.18,<0.9",
     ],
     python_requires=">=3.9,<4",
     extras_require=extras_require,

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -55,3 +55,10 @@ def test_encode_transaction(tx_type, bsc, eth_tester_provider):
     address = "0x274b028b03A250cA03644E6c578D81f019eE1323"
     actual = bsc.encode_transaction(address, abi, sender=address, type=tx_type)
     assert actual.gas_limit == eth_tester_provider.max_gas
+
+
+def test_is_mainnet(bsc):
+    assert bsc.mainnet.is_mainnet
+    assert bsc.opbnb.is_mainnet
+    assert not bsc.testnet.is_mainnet
+    assert not bsc.opbnb_testnet.is_mainnet


### PR DESCRIPTION
### What I did

Uses https://github.com/ApeWorX/ape/pull/2320 but kinda works without it, just more documented with it.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
